### PR TITLE
Update for newer Rust versions

### DIFF
--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -3,8 +3,8 @@
 use riscv::asm;
 
 /// Default panic handler
-#[panic_implementation]
-fn panic_fmt(_info: &core::panic::PanicInfo) -> ! {
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     asm::ebreak();
     loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,12 +167,9 @@
 #![feature(asm)]
 #![feature(compiler_builtins_lib)]
 #![feature(const_fn)]
-#![feature(extern_prelude)]
 #![feature(global_asm)]
 #![feature(lang_items)]
 #![feature(linkage)]
-#![feature(panic_implementation)]
-#![feature(used)]
 
 extern crate riscv;
 extern crate r0;


### PR DESCRIPTION
A couple features are now stable as of Rust 1.30, and panic the definition of the panic_fmt lang item is now slightly different.