### PR TITLE
Remove the unused 'const-fn' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ r0 = "0.2.2"
 riscv = "0.4.0"
 
 [features]
-const-fn = ["riscv/const-fn"]
 inline-asm = ["riscv/inline-asm"]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,7 +4,7 @@ main() {
     cargo check --target $TARGET
 
     if [ $TRAVIS_RUST_VERSION = nightly ]; then
-        cargo check --target $TARGET --features 'const-fn inline-asm'
+        cargo check --target $TARGET --features 'inline-asm'
     fi
 
     if [ $TARGET = x86_64-unknown-linux-gnu ]; then


### PR DESCRIPTION
`const-fn` feature for `riscv` is no longer present: https://github.com/rust-embedded/riscv/pull/18

cc @rust-embedded/riscv