### PR TITLE
[WIP] add entry2 attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ license = "ISC"
 r0 = "0.2.2"
 riscv = "0.4.0"
 
+[dependencies.riscv-rt-macros]
+path = "macros"
+version = "0.1.0"
+
 [features]
 const-fn = ["riscv/const-fn"]
 inline-asm = ["riscv/inline-asm"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors = [
+    # "The RISCV Team <riscv@teams.rust-embedded.org>", # uncomment when mailing list is up
+    "Jorge Aparicio <jorge@japaric.io>",
+]
+name = "riscv-rt-macros"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.6.11"
+
+[dependencies.syn]
+features = ["extra-traits", "full"]
+version = "0.15.26"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = [
-    # "The RISCV Team <riscv@teams.rust-embedded.org>", # uncomment when mailing list is up
+    "The RISCV Team <risc-v@teams.rust-embedded.org>",
     "Jorge Aparicio <jorge@japaric.io>",
 ]
 name = "riscv-rt-macros"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,157 @@
+extern crate proc_macro;
+extern crate quote;
+extern crate syn;
+
+use std::collections::HashSet;
+
+use proc_macro::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    parse, parse_macro_input, spanned::Spanned, AttrStyle, Attribute, Item, ItemFn, ItemStatic,
+    PathArguments, ReturnType, Stmt, Type, Visibility,
+};
+
+#[proc_macro_attribute]
+pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
+    let f = parse_macro_input!(input as ItemFn);
+
+    // check the function signature
+    let valid_signature = f.constness.is_none()
+        && f.vis == Visibility::Inherited
+        && f.abi.is_none()
+        && f.decl.inputs.is_empty()
+        && f.decl.generics.params.is_empty()
+        && f.decl.generics.where_clause.is_none()
+        && f.decl.variadic.is_none()
+        && match f.decl.output {
+            ReturnType::Default => false,
+            ReturnType::Type(_, ref ty) => match **ty {
+                Type::Never(_) => true,
+                _ => false,
+            },
+        };
+
+    if !valid_signature {
+        return parse::Error::new(
+            f.span(),
+            "`#[entry]` function must have signature `[unsafe] fn() -> !`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    if !args.is_empty() {
+        return parse::Error::new(
+            Span::call_site().into(),
+            "This attribute accepts no arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    // XXX should we blacklist other attributes?
+    let attrs = f.attrs;
+    let unsafety = f.unsafety;
+    let ident = f.ident;
+    let (statics, stmts) = match extract_static_muts(f.block.stmts) {
+        Err(e) => return e.to_compile_error().into(),
+        Ok(x) => x,
+    };
+
+    let vars = statics
+        .into_iter()
+        .map(|var| {
+            let (ref cfgs, ref attrs) = extract_cfgs(var.attrs);
+            let ident = var.ident;
+            let ty = var.ty;
+            let expr = var.expr;
+
+            quote!(
+                #[allow(non_snake_case)]
+                #(#cfgs)*
+                let #ident: &'static mut #ty = unsafe {
+                    #(#attrs)*
+                    #(#cfgs)*
+                    static mut #ident: #ty = #expr;
+
+                    &mut #ident
+                };
+            )
+        })
+        .collect::<Vec<_>>();
+
+    quote!(
+        const #ident: () = {
+            #[no_mangle]
+            #(#attrs)*
+            #unsafety extern "C" fn main() -> ! {
+                #(#vars)*
+
+                #(#stmts)*
+            }
+
+            main()
+        };
+    )
+    .into()
+}
+
+/// Extracts `static mut` vars from the beginning of the given statements
+fn extract_static_muts(stmts: Vec<Stmt>) -> Result<(Vec<ItemStatic>, Vec<Stmt>), parse::Error> {
+    let mut istmts = stmts.into_iter();
+
+    let mut seen = HashSet::new();
+    let mut statics = vec![];
+    let mut stmts = vec![];
+    while let Some(stmt) = istmts.next() {
+        match stmt {
+            Stmt::Item(Item::Static(var)) => {
+                if var.mutability.is_some() {
+                    if seen.contains(&var.ident) {
+                        return Err(parse::Error::new(
+                            var.ident.span(),
+                            format!("the name `{}` is defined multiple times", var.ident),
+                        ));
+                    }
+
+                    seen.insert(var.ident.clone());
+                    statics.push(var);
+                } else {
+                    stmts.push(Stmt::Item(Item::Static(var)));
+                }
+            }
+            _ => {
+                stmts.push(stmt);
+                break;
+            }
+        }
+    }
+
+    stmts.extend(istmts);
+
+    Ok((statics, stmts))
+}
+
+fn extract_cfgs(attrs: Vec<Attribute>) -> (Vec<Attribute>, Vec<Attribute>) {
+    let mut cfgs = vec![];
+    let mut not_cfgs = vec![];
+
+    for attr in attrs {
+        if eq(&attr, "cfg") {
+            cfgs.push(attr);
+        } else {
+            not_cfgs.push(attr);
+        }
+    }
+
+    (cfgs, not_cfgs)
+}
+
+/// Returns `true` if `attr.path` matches `name`
+fn eq(attr: &Attribute, name: &str) -> bool {
+    attr.style == AttrStyle::Outer && attr.path.segments.len() == 1 && {
+        let pair = attr.path.segments.first().unwrap();
+        let segment = pair.value();
+        segment.arguments == PathArguments::None && segment.ident.to_string() == name
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,9 @@
 //! Disassembly of section .text:
 //!
 //! 20000000 <_start>:
-//! 20000000:	800011b7          	lui	gp,0x80001
-//! 20000004:	80018193          	addi	gp,gp,-2048 # 80000800 <_stack_start+0xffffc800>
-//! 20000008:	80004137          	lui	sp,0x80004
+//! 20000000:	800011b7            lui	gp,0x80001
+//! 20000004:	80018193            addi	gp,gp,-2048 # 80000800 <_stack_start+0xffffc800>
+//! 20000008:	80004137            lui	sp,0x80004
 //! ```
 //!
 //! # Symbol interfaces
@@ -187,9 +187,12 @@
 #![deny(warnings)]
 
 extern crate riscv;
+extern crate riscv_rt_macros;
 extern crate r0;
 
 use riscv::register::{mstatus, mtvec};
+
+pub use riscv_rt_macros::entry as entry2;
 
 extern "C" {
     // Boundaries of the .bss section


### PR DESCRIPTION
this adds an entry2 attribute in the vein of cortex_m_rt::entry. This attribute
lets you safely use `static mut` variables -- they get transformed into
`&'static mut` references. Example:

``` rust
  #[entry2]
fn main() -> ! {
    static mut COUNT: u32 = 0;

    // user code
    let count: &'static mut = COUNT;
}
```

I did something different in this version: instead of using random identifiers I
wrapped the user entry point into a `const` item to make it impossible to invoke
it from software (if that were allowed using the `static mut` would result in
UB).

Just for reference the above code expands into this:

``` rust
const main: () = {
    #[no_mangle]
    fn main() -> ! {
        let COUNT: &'static mut u32 = {
            static COUNT: u32 = 0;

            &mut COUNT
        };

        // user code
        let count: &'static mut = COUNT;
    }
};
```

Not using random identifiers means that we avoid a (host) dependency on the rand
crate.

This change is a breaking change because it bumps the Minimum Supported Rust
Version (MSRV) to 1.31.0 -- this crate current MSRV is 1.30.0. The MSRV needs to
be bumped because `#[no_mangle]` / `#[link_section]` items inside private
items (like the `const` item above) only get the right symbol visibility in Rust
1.31.0 (the visibility rules around `#[no_mangle]` / `#[link_section]` got
changed in that version).

Instead of naming this attribute: `entry2`, we could replace the existing
`entry!` macro but that would be another breaking change.

I didn't add the interrupt / exception attributes because I couldn't find an
example that makes use of interrupts / exceptions