### PR TITLE
Add .sbss section to linker script

### DIFF
--- a/link.x
+++ b/link.x
@@ -66,7 +66,7 @@ SECTIONS
   .bss :
   {
     _sbss = .;
-    *(.bss .bss.*);
+    *(.sbss .sbss.* .bss .bss.*);
     . = ALIGN(4);
     _ebss = .;
   } > REGION_BSS :virtual


### PR DESCRIPTION
Rust nightly has started generating this section for RISC-V executables, place it at the start of the bss area.

```
  = note: rust-lld: error: no memory region specified for section '.sbss'
```

I think this is correct, looking at other uses of the section, though I could find no definitive documentation for this.