### PR TITLE
link.x: Add .sdata2 sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/rust-embedded/riscv-rt"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]

--- a/link.x
+++ b/link.x
@@ -57,7 +57,7 @@ SECTIONS
     _sdata = .;
     /* Must be called __global_pointer$ for linker relaxations to work. */
     PROVIDE(__global_pointer$ = . + 0x800);
-    *(.sdata .sdata.*);
+    *(.sdata .sdata.* .sdata2 .sdata2.*);
     *(.data .data.*);
     . = ALIGN(4);
     _edata = .;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! $ # add this crate as a dependency
 //! $ edit Cargo.toml && cat $_
 //! [dependencies]
-//! riscv-rt = "0.6.0"
+//! riscv-rt = "0.6.1"
 //! panic-halt = "0.2.0"
 //!
 //! $ # memory layout of the device


### PR DESCRIPTION
Clang doesn't seem to generate these, but GCC (8.3.0 at least) does. I'm trying to link secp256k1, which is a C library, to my Rust code so the linker script needs to include these sections too.