### PR TITLE
Use weak symbol for `_start_trap` procedure

### DIFF
--- a/asm.S
+++ b/asm.S
@@ -126,7 +126,8 @@ _abs_start:
     restores caller saved registers and then returns.
 */
 .section .trap, "ax"
-.global _start_trap
+/* By using weak, upstream IP cores may override with their own trap entry methods */
+.weak _start_trap 
 
 _start_trap:
     addi sp, sp, -16*REGBYTES


### PR DESCRIPTION
By now the `_start_trap` procedure provided from `riscv-rt` is defined as `.global` symbol. But there are some IP cores which require to use their own procedure when entering traps, for example like [this](https://github.com/riscv-mcu/GD32VF103_Firmware_Library/blob/12b61d1bf29afbee8ec4eee81cdbf1bd9f89470a/Firmware/RISCV/env_Eclipse/entry.S#L220-L229) they may need to store vendor defined contexts. Also, [code in `_start` ](https://github.com/rust-embedded/riscv-rt/blob/1238cdf82cc10b3aba071481a03f99d5f983ad08/asm.S#L114-L115) directly stores trap handler address in the process, which means there's by now no way to load IP core defined proper trap handlers into `mtvec` before the runtime is prepared for Rust.

In this pull request I propose to change the `.global` symbol into a `.weak` one for `_start_trap`. In this way, vendor defined IP core crates may feel free to override using their own `.global _start_trap` method for trap handling; and also downstream crates could coexist better with `riscv-rt`.