### PR TITLE
Exception handler may return

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ pub struct TrapFrame {
 #[export_name = "_start_trap_rust"]
 pub extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {
     extern "C" {
-        fn ExceptionHandler(trap_frame: &TrapFrame) -> !;
+        fn ExceptionHandler(trap_frame: &TrapFrame);
         fn DefaultHandler();
     }
 


### PR DESCRIPTION
We need exceptions to be able to return. For example, after fixing the issue that caused them in the first place (e.g. paging), or after emulating missing instructions and possibly updating `mepc`.