### PR TITLE
Update link.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Preserve `.eh_frame` and `.eh_frame_hdr` sections
+- Place `.srodata` and `.srodata.*` sections in `.rodata`
 
 ## [v0.7.1] - 2020-06-02
 

--- a/link.x
+++ b/link.x
@@ -57,6 +57,7 @@ SECTIONS
 
   .rodata : ALIGN(4)
   {
+    *(.srodata .srodata.*);
     *(.rodata .rodata.*);
 
     /* 4-byte align the end (VMA) of this section.


### PR DESCRIPTION
Similar to #38, riscv compilers may also generate 'small ro data' `.srodata` sections. 

This doesn't appear to be well documented, but see [this blog post](https://www.sifive.com/blog/all-aboard-part-3-linker-relaxation-in-riscv-toolchain) for small amount of context.