### PR TITLE
Preserve .eh_frame and .eh_frame_hdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Preserve `.eh_frame` and `.eh_frame_hdr` sections
+
 ## [v0.7.1] - 2020-06-02
 
 ### Added

--- a/link.x
+++ b/link.x
@@ -111,11 +111,8 @@ SECTIONS
     KEEP(*(.got .got.*));
   }
 
-  /* Discard .eh_frame, we are not doing unwind on panic so it is not needed */
-  /DISCARD/ :
-  {
-    *(.eh_frame);
-  }
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
 
 /* Do not exceed this mark in the error messages above                                    | */


### PR DESCRIPTION
Preserving the `.eh_frame` section improves gdb stack traces on nightly.
Preserving the `.eh_frame_hdr` section fixes the linker problem `rust-lld: error: no memory region specified for section '.eh_frame_hdr'` introduced in https://github.com/rust-lang/rust/pull/73564