### PR TITLE
Backport linker script fixes to 0.6.x, release v0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.6.1"
+version = "0.6.2"
 repository = "https://github.com/rust-embedded/riscv-rt"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]

--- a/link.x
+++ b/link.x
@@ -43,6 +43,7 @@ SECTIONS
 
   .rodata : ALIGN(4)
   {
+    *(.srodata .srodata.*);
     *(.rodata .rodata.*);
 
     /* 4-byte align the end (VMA) of this section.

--- a/link.x
+++ b/link.x
@@ -97,11 +97,8 @@ SECTIONS
     KEEP(*(.got .got.*));
   }
 
-  /* Discard .eh_frame, we are not doing unwind on panic so it is not needed */
-  /DISCARD/ :
-  {
-    *(.eh_frame);
-  }
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 }
 
 /* Do not exceed this mark in the error messages above                                    | */


### PR DESCRIPTION
This fix includes the following PRs: https://github.com/rust-embedded/riscv-rt/pull/61, https://github.com/rust-embedded/riscv-rt/pull/62