### PR TITLE
Update `riscv` crate to version 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Update `riscv` to version 0.6
+- Update Minimum Supported Rust Version to 1.42.0
+
 ## [v0.7.2] - 2020-07-16
 
 ### Changed
@@ -22,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
- - Exception handler may return now
+- Exception handler may return now
 
 ## [v0.7.0] - 2020-03-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "ISC"
 
 [dependencies]
 r0 = "1.0.0"
-riscv = "0.5.5"
+riscv = "0.6"
 riscv-rt-macros = { path = "macros", version = "0.1.6" }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.38.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.38 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.42 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 //!
 //! # Features


### PR DESCRIPTION
This pull request solves a probable version conflict between latest `riscv` and `riscv-rt`.

The MSRV is also updated to 1.42.0, since the 0.6.0 version of `riscv` crate requires 1.42.0: [link](https://github.com/rust-embedded/riscv/blob/6392fa9520b042bd559b00b9c7131b6de4189f89/CHANGELOG.md#changed).

This pull request also includes a small typo fix in changelog file.

