### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.8.0] - 2020-07-18
+
 ### Changed
 
 - Update `riscv` to version 0.6
@@ -49,7 +51,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Set MSRV to 1.38
 
 
-[Unreleased]: https://github.com/rust-embedded/riscv-rt/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/rust-embedded/riscv-rt/compare/v0.8.0...HEAD
+[v0.8.0]: https://github.com/rust-embedded/riscv/compare/v0.7.2...v0.8.0
 [v0.7.2]: https://github.com/rust-embedded/riscv/compare/v0.7.1...v0.7.2
 [v0.7.1]: https://github.com/rust-embedded/riscv/compare/v0.7.0...v0.7.1
 [v0.7.0]: https://github.com/rust-embedded/riscv/compare/v0.6.1...v0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.7.2"
+version = "0.8.0"
 repository = "https://github.com/rust-embedded/riscv-rt"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]


### PR DESCRIPTION
This release updates the `riscv` dependency, so that the `bare-metal = ">=0.2.0,<0.2.5"` condition is no longer used.