### PR TITLE
change __pre_init() position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ pub unsafe extern "C" fn start_rust() -> ! {
     if _mp_hook() {
         r0::zero_bss(&mut _sbss, &mut _ebss);
         r0::init_data(&mut _sdata, &mut _edata, &_sidata);
-        
+
         __pre_init();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,10 +376,10 @@ pub unsafe extern "C" fn start_rust() -> ! {
     }
 
     if _mp_hook() {
-        __pre_init();
-
         r0::zero_bss(&mut _sbss, &mut _ebss);
         r0::init_data(&mut _sdata, &mut _edata, &_sidata);
+        
+        __pre_init();
     }
 
     // TODO: Enable FPU when available


### PR DESCRIPTION
This pr change the `__pre_init()` position for some reason:  
if I want to init `some_allocator` in the function following `#[pre_init]`,like this:  
```Rust
#[pre_init]
#[no_mangle]
unsafe fn allocator_init() {
    let heap_bottom = &_sheap as *const u8 as usize;
    let heap_size = &_heap_size as *const u8 as usize;
    ALLOCATOR.lock().init(heap_bottom, heap_size);
}
```
Some error will occur, because after `__pre_init` these codes run:  
```Rust
r0::zero_bss(&mut _sbss, &mut _ebss);
r0::init_data(&mut _sdata, &mut _edata, &_sidata);
```
Then  I run:   
```Rust
let mut data = vec![1, 2, 3, 4, 5];
data.push(6);
```
`alloc_error` will occur.  
So I change the position of `__pre_init`, it works.  
 