### PR TITLE
Update riscv to 0.8 and remove inline-asm feature

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -3,6 +3,6 @@ delete_merged_branches = true
 required_approvals = 1
 status = [
     "ci-linux (stable)",
-    "ci-linux (1.42.0)",
+    "ci-linux (1.59.0)",
     "Rustfmt"
 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       matrix:
-        # All generated code should be running on stable now, MRSV is 1.42.0
-        rust: [nightly, stable, 1.42.0]
+        # All generated code should be running on stable now, MSRV is 1.59.0
+        rust: [nightly, stable, 1.59.0]
 
         include:
           # Nightly is only for reference and allowed to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Update `riscv` to version 0.8
+- Update Minimum Supported Rust Version to 1.59
+
+### Removed
+
+- Remove `inline-asm` feature which is now always enabled
+
 ## [v0.8.1] - 2022-01-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "riscv-rt"
 version = "0.8.1"
+rust-version = "1.59"
 repository = "https://github.com/rust-embedded/riscv-rt"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "no-std"]
@@ -10,11 +11,8 @@ license = "ISC"
 
 [dependencies]
 r0 = "1.0.0"
-riscv = "0.7"
+riscv = "0.8"
 riscv-rt-macros = { path = "macros", version = "0.1.6" }
-
-[features]
-inline-asm = ["riscv/inline-asm"]
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is developed and maintained by the [RISC-V team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.42.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.59 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Minimum Supported Rust Version (MSRV)
 //!
-//! This crate is guaranteed to compile on stable Rust 1.42 and up. It *might*
+//! This crate is guaranteed to compile on stable Rust 1.59 and up. It *might*
 //! compile with older versions but that may change in any new patch release.
 //!
 //! # Features


### PR DESCRIPTION
This also updates MSRV to 1.59.