### PR TITLE
Don't use a random hash ident, instead use the crate prefixed symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update `riscv` to version 0.8
 - Update Minimum Supported Rust Version to 1.59
+- The main symbol is no longer randomly generated in the `#[entry]` macro, instead it uses `__risc_v_rt__main`.
 
 ### Removed
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -22,8 +22,3 @@ proc-macro2 = "1.0"
 [dependencies.syn]
 version = "1.0"
 features = ["extra-traits", "full"]
-
-[dependencies.rand]
-version = "0.7.3"
-default-features = false
-features = ["small_rng"]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 
 extern crate proc_macro;
-extern crate rand;
 #[macro_use]
 extern crate quote;
 extern crate core;
@@ -10,13 +9,7 @@ extern crate proc_macro2;
 extern crate syn;
 
 use proc_macro2::Span;
-use rand::Rng;
-use rand::SeedableRng;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
-use syn::{parse, spanned::Spanned, Ident, ItemFn, ReturnType, Type, Visibility};
-
-static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+use syn::{parse, spanned::Spanned, ItemFn, ReturnType, Type, Visibility};
 
 use proc_macro::TokenStream;
 
@@ -90,13 +83,12 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     // XXX should we blacklist other attributes?
     let attrs = f.attrs;
     let unsafety = f.sig.unsafety;
-    let hash = random_ident();
     let stmts = f.block.stmts;
 
     quote!(
         #[export_name = "main"]
         #(#attrs)*
-        pub #unsafety fn #hash() -> ! {
+        pub #unsafety fn __risc_v_rt__main() -> ! {
             #(#stmts)*
         }
     )
@@ -175,37 +167,4 @@ pub fn pre_init(args: TokenStream, input: TokenStream) -> TokenStream {
         pub unsafe fn #ident() #block
     )
     .into()
-}
-
-// Creates a random identifier
-fn random_ident() -> Ident {
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-
-    let count: u64 = CALL_COUNT.fetch_add(1, Ordering::SeqCst) as u64;
-    let mut seed: [u8; 16] = [0; 16];
-
-    for (i, v) in seed.iter_mut().take(8).enumerate() {
-        *v = ((secs >> (i * 8)) & 0xFF) as u8
-    }
-
-    for (i, v) in seed.iter_mut().skip(8).enumerate() {
-        *v = ((count >> (i * 8)) & 0xFF) as u8
-    }
-
-    let mut rng = rand::rngs::SmallRng::from_seed(seed);
-    Ident::new(
-        &(0..16)
-            .map(|i| {
-                if i == 0 || rng.gen() {
-                    ('a' as u8 + rng.gen::<u8>() % 25) as char
-                } else {
-                    ('0' as u8 + rng.gen::<u8>() % 10) as char
-                }
-            })
-            .collect::<String>(),
-        Span::call_site(),
-    )
 }


### PR DESCRIPTION
This is what cortex-m land is doing. This was initially discovered to be an issue when implementing unwinding in riscv probe-rs, the dwarf info shows the hashed symbol name which is a bit weird, this makes it more clear what the symbol actually is.