### PR TITLE
Rerun the build script if the bin/{}.a archive has changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,5 @@ fn main() {
     // Put the linker script somewhere the linker can find it
     fs::write(out_dir.join("link.x"), include_bytes!("link.x")).unwrap();
     println!("cargo:rustc-link-search={}", out_dir.display());
-
-    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=link.x");
 }

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,6 @@ fn main() {
         .unwrap();
 
         println!("cargo:rustc-link-lib=static={}", name);
-        println!("cargo:rustc-link-search={}", out_dir.display());
     }
 
     // Put the linker script somewhere the linker can find it

--- a/build.rs
+++ b/build.rs
@@ -14,15 +14,10 @@ fn main() {
     if target.starts_with("riscv") {
         let mut target = Target::from_target_str(&target);
         target.retain_extensions("imfdc");
+        let archive = format!("bin/{}.a", target.to_string());
 
-        let target = target.to_string();
-
-        fs::copy(
-            format!("bin/{}.a", target),
-            out_dir.join(format!("lib{}.a", name)),
-        )
-        .unwrap();
-
+        fs::copy(&archive, out_dir.join(format!("lib{}.a", name))).unwrap();
+        println!("cargo:rerun-if-changed={}", archive);
         println!("cargo:rustc-link-lib=static={}", name);
     }
 

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ extern crate riscv_target;
 use riscv_target::Target;
 use std::env;
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
@@ -29,10 +28,7 @@ fn main() {
     }
 
     // Put the linker script somewhere the linker can find it
-    fs::File::create(out_dir.join("link.x"))
-        .unwrap()
-        .write_all(include_bytes!("link.x"))
-        .unwrap();
+    fs::write(out_dir.join("link.x"), include_bytes!("link.x")).unwrap();
     println!("cargo:rustc-link-search={}", out_dir.display());
 
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
This PR also includes some drive-by cleanup commits, but the last one is what’s significant. This bit me when trying to make changes to `asm.S` and rebuilding with `./assemble.sh`.

(By the way, I get ``Assembler messages: Fatal error: invalid -march= option: `rv32i'`` when running that script on Arch Linux despite installing a GNU toolchain for RISC-V. Instead I’m now using an Ubuntu 20.04 container to run it, since that’s what CI does for `./check-blobs.sh`.)