### PR TITLE
Add embedded-hal v1.0.0-alpha.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Update `riscv` to version 0.9-alpha.1
+
 ## [v0.9.0] - 2022-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-rt"
-version = "0.9.0"
+version = "0.10.0-alpha.1"
 rust-version = "1.59"
 repository = "https://github.com/rust-embedded/riscv-rt"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 r0 = "1.0.0"
-riscv = "0.8"
+riscv = "0.9.0-alpha.1"
 riscv-rt-macros = { path = "macros", version = "0.2.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps riscv dependency to match embedded-hal v1.0.0-alpha.8