### PR TITLE
update to riscv 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Update `riscv` to version 0.10
+
 ## [v0.10.0] - 2022-11-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ s-mode = []
 
 [dependencies]
 r0 = "1.0.0"
-riscv = "0.9"
+riscv = "0.10"
 riscv-rt-macros = { path = "macros", version = "0.2.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
In `svd2rust` 0.24.2, require `critial-section` feature of `riscv` 0.10.0 to use the `Peripheral::take()`. So update `riscv` to 0.10 avoid link error.

```text
  = note: rust-lld: error: undefined symbol: _critical_section_1_0_release
          >>> referenced by lib.rs:197 (C:\***\.cargo\registry\src\github.com-1ecc6299db9ec823\critical-section-1.1.1\src/lib.rs:197)
          >>>               C:\***\target\riscv32imac-unknown-none-elf\debug\deps\blink-38e172683ad1eb45.21kbt3gcucoa48u6.rcgu.o:(core::ptr::drop_in_place$LT$critical_section..with..Guard$GT$::h47fa1a207a83c94b)

          rust-lld: error: undefined symbol: _critical_section_1_0_acquire
          >>> referenced by lib.rs:180 (C:\***\.cargo\registry\src\github.com-1ecc6299db9ec823\critical-section-1.1.1\src/lib.rs:180)
          >>>               C:\***\target\riscv32imac-unknown-none-elf\debug\deps\blink-38e172683ad1eb45.54bke7unpav17a81.rcgu.o:(critical_section::with::h3ba86eebd468f130)
```