### PR TITLE
fix: avoid rust-analyzer snake case warning

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -109,6 +109,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     let stmts = f.block.stmts;
 
     quote!(
+        #[allow(non_snake_case)]
         #[export_name = "main"]
         #(#attrs)*
         pub #unsafety fn __risc_v_rt__main(#args) -> ! {


### PR DESCRIPTION
It seems that rust-analyzer needs to operate over the expanded text of the proc macro (in order to e.g. support completion in the function body, see #11014 for way more details), so it "sees" the non-snake-case name emitted by riscv-rt's `entry` here.

Without this change, rust-analyzer will show a "weak warning" on invocations of `#[entry]` with the text:

```
Function `__risc_v_rt__main` should have snake_case name, e.g. `__risc_v_rt_main`
```