### PR TITLE
Exceptions enum and table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Added
+
+- Standard exceptions enum 
+- __EXCEPTIONS array for dedicated handlers for each exception type.
+
 ## [v0.11.0] - 2023-01-18
 
 ### Changed

--- a/link.x
+++ b/link.x
@@ -4,6 +4,21 @@ PROVIDE(_max_hart_id = 0);
 PROVIDE(_hart_stack_size = 2K);
 PROVIDE(_heap_size = 0);
 
+PROVIDE(InstrAddressMisaligned = ExceptionHandler);
+PROVIDE(InstrAccessFault = ExceptionHandler);
+PROVIDE(IlegalInstr = ExceptionHandler);
+PROVIDE(Breakpoint = ExceptionHandler);
+PROVIDE(LoadAddressMisaligned = ExceptionHandler);
+PROVIDE(LoadAccessFault = ExceptionHandler);
+PROVIDE(StoreAMOAddressMisaligned = ExceptionHandler);
+PROVIDE(StoreAMOAccessFault = ExceptionHandler);
+PROVIDE(EnvUserCall = ExceptionHandler);
+PROVIDE(EnvSupervisorCall = ExceptionHandler);
+PROVIDE(EnvMachineCall = ExceptionHandler);
+PROVIDE(InstrPageFault = ExceptionHandler);
+PROVIDE(LoadPageFault = ExceptionHandler);
+PROVIDE(StoreAMOPageFault = ExceptionHandler);
+
 PROVIDE(UserSoft = DefaultHandler);
 PROVIDE(SupervisorSoft = DefaultHandler);
 PROVIDE(MachineSoft = DefaultHandler);


### PR DESCRIPTION
I added an exception type enum and an exception handler table following the interrupts' fashion.
- The standard exception types are defined in SiFive's [interrupt cookbook](https://starfivetech.com/uploads/sifive-interrupt-cookbook-v1p2.pdf).
- For the exception handlers, I used `Option<unsafe extern "C" fn(&TrapFrame)>` instead of a union struct. The Rust compiler provides a niche optimization to represent `None` as 0 instead of adding an additional byte. This way is more rustacean than using a union and it is [FFI safe](https://github.com/rust-lang/unsafe-code-guidelines/blob/master/reference/src/layout/function-pointers.md).
- By default, all the exception handlers are set to `ExceptionHandler`, so this PR should not break previous works that depended on a single handler.