### PR TITLE
Temporary fix for OOR branch

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -92,7 +92,11 @@ _abs_start:
     "csrr t2, mhartid",
     "lui t0, %hi(_max_hart_id)
     add t0, t0, %lo(_max_hart_id)
-    bgtu t2, t0, abort
+    // bgtu t2, t0, abort
+    bleu t2, t0, not_abort
+    la t0, abort
+    jr t0
+    not_abort:
 
     // Allocate stacks
     la sp, _stack_start


### PR DESCRIPTION
This implements the temp fix i mentioned on matrix, seems to pass CI.. A better way to go about this would probably be to move the abort routine somewhere closer to the affected branch.