### PR TITLE
Fix oor branch via linking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ master, global_asm, global_asm_link ]
+    branches: [ master, global_asm ]
   pull_request:
   merge_group:
 
@@ -47,4 +47,3 @@ jobs:
     if: always()
     steps:
       - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
-  

--- a/link.x
+++ b/link.x
@@ -55,7 +55,7 @@ SECTIONS
     KEEP(*(.init));
     KEEP(*(.init.rust));
     . = ALIGN(4);
-    *(.abort)
+    *(.abort);
     *(.trap);
     *(.trap.rust);
 

--- a/link.x
+++ b/link.x
@@ -4,6 +4,8 @@ PROVIDE(_max_hart_id = 0);
 PROVIDE(_hart_stack_size = 2K);
 PROVIDE(_heap_size = 0);
 
+beep boop xdd
+
 PROVIDE(UserSoft = DefaultHandler);
 PROVIDE(SupervisorSoft = DefaultHandler);
 PROVIDE(MachineSoft = DefaultHandler);

--- a/link.x
+++ b/link.x
@@ -55,6 +55,7 @@ SECTIONS
     KEEP(*(.init));
     KEEP(*(.init.rust));
     . = ALIGN(4);
+    *(.abort)
     *(.trap);
     *(.trap.rust);
 

--- a/link.x
+++ b/link.x
@@ -4,7 +4,6 @@ PROVIDE(_max_hart_id = 0);
 PROVIDE(_hart_stack_size = 2K);
 PROVIDE(_heap_size = 0);
 
-
 PROVIDE(UserSoft = DefaultHandler);
 PROVIDE(SupervisorSoft = DefaultHandler);
 PROVIDE(MachineSoft = DefaultHandler);

--- a/link.x
+++ b/link.x
@@ -4,7 +4,6 @@ PROVIDE(_max_hart_id = 0);
 PROVIDE(_hart_stack_size = 2K);
 PROVIDE(_heap_size = 0);
 
-beep boop xdd
 
 PROVIDE(UserSoft = DefaultHandler);
 PROVIDE(SupervisorSoft = DefaultHandler);
@@ -57,10 +56,9 @@ SECTIONS
     KEEP(*(.init));
     KEEP(*(.init.rust));
     . = ALIGN(4);
-    *(.abort);
     *(.trap);
     *(.trap.rust);
-
+    *(.text.abort);
     *(.text .text.*);
   } > REGION_TEXT
 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -92,11 +92,7 @@ _abs_start:
     "csrr t2, mhartid",
     "lui t0, %hi(_max_hart_id)
     add t0, t0, %lo(_max_hart_id)
-    // bgtu t2, t0, abort
-    bleu t2, t0, not_abort
-    la t0, abort
-    jr t0
-    not_abort:
+    bgtu t2, t0, abort
 
     // Allocate stacks
     la sp, _stack_start

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -92,7 +92,11 @@ _abs_start:
     "csrr t2, mhartid",
     "lui t0, %hi(_max_hart_id)
     add t0, t0, %lo(_max_hart_id)
-    bgtu t2, t0, abort
+    // bgtu t2, t0, abort
+    bleu t2, t0, not_abort
+    la t0, abort
+    jr t0
+    not_abort:
 
     // Allocate stacks
     la sp, _stack_start


### PR DESCRIPTION
This restores the abort branch to the original state and instead moves the abort loop closer via the linker script. Give it a go :)