### PR TITLE
Add feature single-hart

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [features]
 s-mode = []
+single-hart = []
 
 [dependencies]
 r0 = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,10 @@
 //!
 //! # Features
 //!
+//! ## `single-hart`
+//!
+//! This feature saves a little code size by removing unnecessary stack space calculation if there is only one hart on the target.
+//!
 //! ## `s-mode`
 //!
 //! The supervisor mode feature (`s-mode`) can be activated via [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html).


### PR DESCRIPTION
The patch saves a little code size by removing unnecessary stack space calculation if there is only one hart, as most MCUs are. 
This is achieved by adding a feature, "single-hart", which is disabled by default to maintain compatibility.