### PR TITLE
Implement r0 crate in assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use inline assembly instead of pre-compiled blobs
 - Removed bors in favor of GitHub Merge Queue
 - `start_trap_rust` is now marked as `unsafe`
+- Implement `r0` as inline assembly
 
 ## [v0.11.0] - 2023-01-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ s-mode = []
 single-hart = []
 
 [dependencies]
-r0 = "1.0.0"
 riscv = "0.10"
 riscv-rt-macros = { path = "macros", version = "0.2.0" }
 

--- a/build.rs
+++ b/build.rs
@@ -5,9 +5,17 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+fn add_linker_script(bytes: &[u8]) {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // Put the linker script somewhere the linker can find it
+    fs::write(out_dir.join("link.x"), bytes).unwrap();
+    println!("cargo:rustc-link-search={}", out_dir.display());
+    println!("cargo:rerun-if-changed=link.x");
+}
+
 fn main() {
     let target = env::var("TARGET").unwrap();
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let _name = env::var("CARGO_PKG_NAME").unwrap();
 
     // set configuration flags depending on the target
@@ -17,9 +25,11 @@ fn main() {
         match target.bits {
             32 => {
                 println!("cargo:rustc-cfg=riscv32");
+                add_linker_script(include_bytes!("link-rv32.x"));
             }
             64 => {
                 println!("cargo:rustc-cfg=riscv64");
+                add_linker_script(include_bytes!("link-rv64.x"));
             }
             _ => panic!("Unsupported bit width"),
         }
@@ -27,9 +37,4 @@ fn main() {
             println!("cargo:rustc-cfg=riscvm"); // we can expose extensions this way
         }
     }
-
-    // Put the linker script somewhere the linker can find it
-    fs::write(out_dir.join("link.x"), include_bytes!("link.x")).unwrap();
-    println!("cargo:rustc-link-search={}", out_dir.display());
-    println!("cargo:rerun-if-changed=link.x");
 }

--- a/link-rv32.x
+++ b/link-rv32.x
@@ -1,0 +1,174 @@
+PROVIDE(_stext = ORIGIN(REGION_TEXT));
+PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
+PROVIDE(_max_hart_id = 0);
+PROVIDE(_hart_stack_size = 2K);
+PROVIDE(_heap_size = 0);
+
+PROVIDE(UserSoft = DefaultHandler);
+PROVIDE(SupervisorSoft = DefaultHandler);
+PROVIDE(MachineSoft = DefaultHandler);
+PROVIDE(UserTimer = DefaultHandler);
+PROVIDE(SupervisorTimer = DefaultHandler);
+PROVIDE(MachineTimer = DefaultHandler);
+PROVIDE(UserExternal = DefaultHandler);
+PROVIDE(SupervisorExternal = DefaultHandler);
+PROVIDE(MachineExternal = DefaultHandler);
+
+PROVIDE(DefaultHandler = DefaultInterruptHandler);
+PROVIDE(ExceptionHandler = DefaultExceptionHandler);
+
+/* # Pre-initialization function */
+/* If the user overrides this using the `#[pre_init]` attribute or by creating a `__pre_init` function,
+   then the function this points to will be called before the RAM is initialized. */
+PROVIDE(__pre_init = default_pre_init);
+
+/* A PAC/HAL defined routine that should initialize custom interrupt controller if needed. */
+PROVIDE(_setup_interrupts = default_setup_interrupts);
+
+/* # Multi-processing hook function
+   fn _mp_hook() -> bool;
+
+   This function is called from all the harts and must return true only for one hart,
+   which will perform memory initialization. For other harts it must return false
+   and implement wake-up in platform-dependent way (e.g. after waiting for a user interrupt).
+*/
+PROVIDE(_mp_hook = default_mp_hook);
+
+/* # Start trap function override
+  By default uses the riscv crates default trap handler
+  but by providing the `_start_trap` symbol external crates can override.
+*/
+PROVIDE(_start_trap = default_start_trap);
+
+SECTIONS
+{
+  .text.dummy (NOLOAD) :
+  {
+    /* This section is intended to make _stext address work */
+    . = ABSOLUTE(_stext);
+  } > REGION_TEXT
+
+  .text _stext :
+  {
+    /* Put reset handler first in .text section so it ends up as the entry */
+    /* point of the program. */
+    KEEP(*(.init));
+    KEEP(*(.init.rust));
+    . = ALIGN(4);
+    *(.trap);
+    *(.trap.rust);
+    *(.text.abort);
+    *(.text .text.*);
+  } > REGION_TEXT
+
+  .rodata : ALIGN(4)
+  {
+    *(.srodata .srodata.*);
+    *(.rodata .rodata.*);
+
+    /* 4-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(4);
+  } > REGION_RODATA
+
+  .data : ALIGN(4)
+  {
+    _sidata = LOADADDR(.data);
+    _sdata = .;
+    /* Must be called __global_pointer$ for linker relaxations to work. */
+    PROVIDE(__global_pointer$ = . + 0x800);
+    *(.sdata .sdata.* .sdata2 .sdata2.*);
+    *(.data .data.*);
+    . = ALIGN(4);
+    _edata = .;
+  } > REGION_DATA AT > REGION_RODATA
+
+  .bss (NOLOAD) : ALIGN(4)
+  {
+    _sbss = .;
+    *(.sbss .sbss.* .bss .bss.*);
+    . = ALIGN(4);
+    _ebss = .;
+  } > REGION_BSS
+
+  /* fictitious region that represents the memory available for the heap */
+  .heap (NOLOAD) :
+  {
+    _sheap = .;
+    . += _heap_size;
+    . = ALIGN(4);
+    _eheap = .;
+  } > REGION_HEAP
+
+  /* fictitious region that represents the memory available for the stack */
+  .stack (NOLOAD) :
+  {
+    _estack = .;
+    . = ABSOLUTE(_stack_start);
+    _sstack = .;
+  } > REGION_STACK
+
+  /* fake output .got section */
+  /* Dynamic relocations are unsupported. This section is only used to detect
+     relocatable code in the input files and raise an error if relocatable code
+     is found */
+  .got (INFO) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+}
+
+/* Do not exceed this mark in the error messages above                                    | */
+ASSERT(ORIGIN(REGION_TEXT) % 4 == 0, "
+ERROR(riscv-rt): the start of the REGION_TEXT must be 4-byte aligned");
+
+ASSERT(ORIGIN(REGION_RODATA) % 4 == 0, "
+ERROR(riscv-rt): the start of the REGION_RODATA must be 4-byte aligned");
+
+ASSERT(ORIGIN(REGION_DATA) % 4 == 0, "
+ERROR(riscv-rt): the start of the REGION_DATA must be 4-byte aligned");
+
+ASSERT(ORIGIN(REGION_HEAP) % 4 == 0, "
+ERROR(riscv-rt): the start of the REGION_HEAP must be 4-byte aligned");
+
+ASSERT(ORIGIN(REGION_TEXT) % 4 == 0, "
+ERROR(riscv-rt): the start of the REGION_TEXT must be 4-byte aligned");
+
+ASSERT(ORIGIN(REGION_STACK) % 4 == 0, "
+ERROR(riscv-rt): the start of the REGION_STACK must be 4-byte aligned");
+
+ASSERT(_stext % 4 == 0, "
+ERROR(riscv-rt): `_stext` must be 4-byte aligned");
+
+ASSERT(_sdata % 4 == 0 && _edata % 4 == 0, "
+BUG(riscv-rt): .data is not 4-byte aligned");
+
+ASSERT(_sidata % 4 == 0, "
+BUG(riscv-rt): the LMA of .data is not 4-byte aligned");
+
+ASSERT(_sbss % 4 == 0 && _ebss % 4 == 0, "
+BUG(riscv-rt): .bss is not 4-byte aligned");
+
+ASSERT(_sheap % 4 == 0, "
+BUG(riscv-rt): start of .heap is not 4-byte aligned");
+
+ASSERT(_stext + SIZEOF(.text) < ORIGIN(REGION_TEXT) + LENGTH(REGION_TEXT), "
+ERROR(riscv-rt): The .text section must be placed inside the REGION_TEXT region.
+Set _stext to an address smaller than 'ORIGIN(REGION_TEXT) + LENGTH(REGION_TEXT)'");
+
+ASSERT(SIZEOF(.stack) > (_max_hart_id + 1) * _hart_stack_size, "
+ERROR(riscv-rt): .stack section is too small for allocating stacks for all the harts.
+Consider changing `_max_hart_id` or `_hart_stack_size`.");
+
+ASSERT(SIZEOF(.got) == 0, "
+.got section detected in the input files. Dynamic relocations are not
+supported. If you are linking to C code compiled using the `gcc` crate
+then modify your build script to compile the C code _without_ the
+-fPIC flag. See the documentation of the `gcc::Config.fpic` method for
+details.");
+
+/* Do not exceed this mark in the error messages above                                    | */

--- a/link-rv64.x
+++ b/link-rv64.x
@@ -72,7 +72,7 @@ SECTIONS
     . = ALIGN(4);
   } > REGION_RODATA
 
-  .data : ALIGN(4)
+  .data : ALIGN(8)
   {
     _sidata = LOADADDR(.data);
     _sdata = .;
@@ -80,15 +80,15 @@ SECTIONS
     PROVIDE(__global_pointer$ = . + 0x800);
     *(.sdata .sdata.* .sdata2 .sdata2.*);
     *(.data .data.*);
-    . = ALIGN(4);
+    . = ALIGN(8);
     _edata = .;
   } > REGION_DATA AT > REGION_RODATA
 
-  .bss (NOLOAD) : ALIGN(4)
+  .bss (NOLOAD) : ALIGN(8)
   {
     _sbss = .;
     *(.sbss .sbss.* .bss .bss.*);
-    . = ALIGN(4);
+    . = ALIGN(8);
     _ebss = .;
   } > REGION_BSS
 
@@ -129,8 +129,8 @@ ERROR(riscv-rt): the start of the REGION_TEXT must be 4-byte aligned");
 ASSERT(ORIGIN(REGION_RODATA) % 4 == 0, "
 ERROR(riscv-rt): the start of the REGION_RODATA must be 4-byte aligned");
 
-ASSERT(ORIGIN(REGION_DATA) % 4 == 0, "
-ERROR(riscv-rt): the start of the REGION_DATA must be 4-byte aligned");
+ASSERT(ORIGIN(REGION_DATA) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_DATA must be 8-byte aligned");
 
 ASSERT(ORIGIN(REGION_HEAP) % 4 == 0, "
 ERROR(riscv-rt): the start of the REGION_HEAP must be 4-byte aligned");
@@ -144,18 +144,14 @@ ERROR(riscv-rt): the start of the REGION_STACK must be 4-byte aligned");
 ASSERT(_stext % 4 == 0, "
 ERROR(riscv-rt): `_stext` must be 4-byte aligned");
 
-ASSERT(_sdata % 4 == 0 && _edata % 4 == 0, "
-BUG(riscv-rt): .data is not 4-byte aligned");
+ASSERT(_sdata % 8 == 0 && _edata % 8 == 0, "
+BUG(riscv-rt): .data is not 8-byte aligned");
 
-ASSERT(_sidata % 4 == 0, "
-BUG(riscv-rt): the LMA of .data is not 4-byte aligned");
+ASSERT(_sidata % 8 == 0, "
+BUG(riscv-rt): the LMA of .data is not 8-byte aligned");
 
-/* Make sure that we can safely perform .data initialization on RV64 */ 
-ASSERT(_sidata % 8 == _sdata % 8, "
-BUG(riscv-rt): .data is not similarly 8-byte aligned to the LMA of .data");
-
-ASSERT(_sbss % 4 == 0 && _ebss % 4 == 0, "
-BUG(riscv-rt): .bss is not 4-byte aligned");
+ASSERT(_sbss % 8 == 0 && _ebss % 8 == 0, "
+BUG(riscv-rt): .bss is not 8-byte aligned");
 
 ASSERT(_sheap % 4 == 0, "
 BUG(riscv-rt): start of .heap is not 4-byte aligned");

--- a/link.x
+++ b/link.x
@@ -84,7 +84,7 @@ SECTIONS
     _edata = .;
   } > REGION_DATA AT > REGION_RODATA
 
-  .bss (NOLOAD) :
+  .bss (NOLOAD) : ALIGN(4)
   {
     _sbss = .;
     *(.sbss .sbss.* .bss .bss.*);

--- a/link.x
+++ b/link.x
@@ -150,6 +150,10 @@ BUG(riscv-rt): .data is not 4-byte aligned");
 ASSERT(_sidata % 4 == 0, "
 BUG(riscv-rt): the LMA of .data is not 4-byte aligned");
 
+/* Make sure that we can safely perform .data initialization on RV64 */ 
+ASSERT(_sidata % 8 == _sdata % 8, "
+BUG(riscv-rt): .data is not similarly 8-byte aligned to the LMA of .data");
+
 ASSERT(_sbss % 4 == 0 && _ebss % 4 == 0, "
 BUG(riscv-rt): .bss is not 4-byte aligned");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,8 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
         // Initialize RAM
         // 1. Copy over .data from flash to RAM
         // 2. Zero out .bss
+
+        #[cfg(target_arch = "riscv32")]
         core::arch::asm!(
             "
                 // Copy over .data
@@ -453,6 +455,100 @@ pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
             end = out(reg) _,
             input = out(reg) _,
             a = out(reg) _,
+        );
+
+        #[cfg(target_arch = "riscv64")]
+        core::arch::asm!(
+            "
+                // Copy over .data
+                la      {start},_sdata
+                la      {end},_edata
+                la      {input},_sidata
+
+                bgeu    {start},{end},3f
+
+                //    If _sdata and _sidata are not 8-byte aligned, we copy one word before the main loop. This way, in
+                //    the main loop, we are sure `start` and `input` are 8-byte aligned. This is needed to safely
+                //    perform load and store double instructions.
+                //
+                //    NOTE: We assert in the `link.x` file that _sdata and _sidata are similarly 8-byte aligned. This is
+                //          needed for the main loop here.
+                andi    {b},{start},4
+                beqz    {b},0f
+                lw      {a},0({input})
+                addi    {input},{input},4
+                sw      {a},0({start})
+                addi    {start},{start},4
+
+            0: // .data Main Loop Initialization
+                //    b = FLOOR_ALIGN(_edata, 4)
+                andi    {b},{end},4
+                sub     {b},{end},{b}
+
+            	bgeu    {start},{b},2f
+            1: // .data Main Loop
+            	ld      {a},0({input})
+            	addi    {input},{input},8
+            	sd      {a},0({start})
+            	addi    {start},{start},8
+            	bltu    {start},{b},1b
+            
+            2: // .data end align
+                //    If _edata is not 8-byte aligned, we copy one word after the main loop. This way we are sure we
+                //    copied all the data even if _edata is 4-byte aligned.
+                andi    {b},{end},4
+                beqz    {b},3f
+                lw      {a},0({input})
+                addi    {input},{input},4
+                sw      {a},0({start})
+                addi    {start},{start},4
+            
+            3: // .data zero registers
+                li      {a},0
+                li      {input},0
+
+            4: // zero out .bss start
+            	la      {start},_sbss
+            	la      {end},_ebss
+            
+                bgeu    {start},{end},8f
+
+                //    If _sbss is not 8-byte aligned, we zero one word before the main loop. This way, in the main
+                //    loop, we are sure `start` is 8-byte aligned. This is needed to safely perform store double
+                //    instruction.
+                andi    {b},{start},4
+                beqz    {b},5f
+            	sw      zero,0({start})
+            	addi    {start},{start},4
+
+            5: // .bss main loop initialization
+                //    b = FLOOR_ALIGN(_ebss, 4)
+                andi    {b},{end},4
+                sub     {b},{end},{b}
+
+            	bgeu    {start},{b},7f
+            6: // .bss main loop
+            	sd      zero,0({start})
+            	addi    {start},{start},8
+            	bltu    {start},{b},6b
+
+            7: // .bss end align
+                //    If _ebss is not 8-byte aligned, we need to zero more one word after the main loop.
+                andi    {b},{end},4
+                beqz    {b},8f
+            	sw      zero,0({start})
+
+            8: // .bss zero registers
+                //    Zero out used registers
+                li      {b},0
+                li      {start},0
+                li      {end},0
+        ",
+            start = out(reg) _,
+            end = out(reg) _,
+            input = out(reg) _,
+            a = out(reg) _,
+            b = out(reg) _,
         );
 
         compiler_fence(Ordering::SeqCst);


### PR DESCRIPTION
This implements the `r0::init_data` and `r0::zero_bss` routines in assembly. There is a generic implementation for `riscv32` and `riscv64`, since a `riscv64` would deal with alignment problems. The routines are kept at their old calling site so that only one hardware thread calls them. Consequently they are also inlined into the `start_rust` function.

One special consideration I ran into is the alignment constraints for the `.bss` and `.data` sections. In the documentation for `r0`, it notes that the `.bss` section should also be aligned to 4 byte. This makes a lot of sense since it was using `u32`s as enforcing alignment of the sections. The current `link.x` file does not have this constraint. It is added for the `.data` section and therefore I am assuming it to be a bug. I added it in since it is also required for this patch to work correctly.

Ideally, for the `riscv64` implement we could use the 64-bit instructions load and store instructions. This is currently not possible. We could overcome the 4 byte alignment without changing the `link.x` script by using the follow code.

```rust
core::arch::asm!(
    "
        // Copy over .data
        la      {start},_sdata
        la      {end},_edata
        la      {input},_sidata

        andi    {a},{start},4
        beqz    {a},1f
        lw      {b},0({input})
        sw      {b},0({start})
        addi    {input},{input},4
        addi    {start},{start},4

    1:
    	addi    {a},{start},8
    	bgeu    {a},{end},1f
    	ld      {b},0({input})
    	sd      {b},0({start})
    	addi    {start},{start},8
    	addi    {input},{input},8
    	j       1b

    1:
        andi    {a},{end},4
        beqz    {a},1f
        lw      {b},0({input})
    	sw      {b},0({start})

    1:
        // Zero out .bss
    	la      {start},_sbss
    	la      {end},_ebss

        andi    {b},{start},4
        beqz    {b},2f
    	sw      zero,0({start})
    	addi    {start},{start},4

    2:
    	addi    {a},{start},8
    	bgeu    {a},{end},2f
    	sd      zero,0({start})
    	addi    {start},{start},8
    	j       2b

    2:
        andi    {b},{end},4
        beqz    {b},2f
    	sw      zero,0({start})

    2:
        li      {start},0
        li      {end},0
        li      {input},0
    ",
    start = out(reg) _,
    end = out(reg) _,
    input = out(reg) _,
    a = out(reg) _,
    b = out(reg) _,
);
```

I did try this but it might still lead to problematic behavior since now there is a chance that the `_sidata` is differently aligned than `_sdata`. In which case, we use load and store instructions on unaligned addresses. This might cause exceptions according to the RISC-V Manual. Therefore, we also need to ensure the alignment of the `_sidata` section. We could assert this, but again, this might be undesirable.

As proposed as well in #122 we could add a feature to zero out the entire RAM, but I believe that to be a separate issue onto itself.

Fixes #122
