### PR TITLE
Check CHANGELOG.md on PRs to master

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  check_changelog:
+  changelog-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,6 +1,7 @@
 name: Check CHANGELOG.md
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
@@ -14,5 +15,6 @@ jobs:
       - name: Check for CHANGELOG.md
         uses: dangoslen/changelog-enforcer@v3
         with:
+          skipLabels: 'skip changelog'
           missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md file.'
 

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,22 @@
+name: Check CHANGELOG.md
+
+on:
+  push:
+    branches: [ master, check-changelog ]
+  pull_request:
+  merge_group:
+
+jobs:
+  check_changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check for CHANGELOG.md
+        run: |
+          if ! git diff --name-only HEAD^ | grep -q "^CHANGELOG.md$"; then
+            echo "ERROR: CHANGELOG.md not modified in this pull request"
+            exit 1
+          fi

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,22 +1,18 @@
 name: Check CHANGELOG.md
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
   check_changelog:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for CHANGELOG.md
-        run: |
-          if ! git diff --name-only HEAD^ | grep -q "^CHANGELOG.md$"; then
-            echo "ERROR: CHANGELOG.md not modified in this pull request"
-            exit 1
-          fi
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+          missingUpdateErrorMessage: 'Please add a changelog entry in the CHANGELOG.md file.'
+

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -2,9 +2,9 @@ name: Check CHANGELOG.md
 
 on:
   push:
-    branches: [ master, check-changelog ]
+    branches: [ master ]
   pull_request:
-  merge_group:
+    branches: [ master ]
 
 jobs:
   check_changelog:

--- a/.github/workflows/gh_labels.yaml
+++ b/.github/workflows/gh_labels.yaml
@@ -1,0 +1,19 @@
+name: Check Labels
+on:
+  merge_group:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - id: labels-check
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 0
+          labels: "work in progress, do not merge"
+          add_comment: true
+          message: "This PR is being prevented from merging because it presents one of the blocking labels: {{ provided }}."
+

--- a/.github/workflows/gh_labels.yaml
+++ b/.github/workflows/gh_labels.yaml
@@ -5,11 +5,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  label:
+  label-check:
     runs-on: ubuntu-latest
     steps:
-      - id: labels-check
-        uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly
           count: 0

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,4 +1,5 @@
 name: Check Labels
+
 on:
   merge_group:
   pull_request:
@@ -15,4 +16,3 @@ jobs:
           labels: "work in progress, do not merge"
           add_comment: true
           message: "This PR is being prevented from merging because it presents one of the blocking labels: {{ provided }}."
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- New GitHub worklow for checking modifications on CHANGELOG.md
 - New GitHub workflow for checking clippy lints in PRs
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- New GitHub worklow for checking modifications on CHANGELOG.md
+- New GitHub workflow for checking invalid labels in PRs
+- New GitHub workflow for checking modifications on CHANGELOG.md
 - New GitHub workflow for checking clippy lints in PRs
 
 ### Changed


### PR DESCRIPTION
I added a new CI check that fails if `CHANGELOG.md` has not been modified on PRs to `master`.

I left this workflow out of GHMQ in case we still want to merge small changes that do not need a record on `CHANGELOG.md`. However, it will help us not to forget about updating this file :)