### PR TITLE
Remove label-check from merge_group

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,7 +1,6 @@
 name: Check Labels
 
 on:
-  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 


### PR DESCRIPTION
It seems that the action used to check forbidden labels only works for PRs. Removing it from merge_group.