### PR TITLE
Ignore hartid in single-hart mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed bors in favor of GitHub Merge Queue
 - `start_trap_rust` is now marked as `unsafe`
 - Implement `r0` as inline assembly
+- mhartid CSR is no longer read in single-hart mode, assumed zero
 
 ## [v0.11.0] - 2023-01-18
 


### PR DESCRIPTION
Don't bother checking hart ID on startup in single-hart mode. Allows use of cores with unusual mhartid values and saves a few instructions.