### PR TITLE
Fix setting incorrect sp if single-hart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New GitHub workflow for checking invalid labels in PRs
 - New GitHub workflow for checking modifications on CHANGELOG.md
 - New GitHub workflow for checking clippy lints in PRs
+- Optional cargo feature `single-hart` for single CPU targets
 
 ### Changed
 

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -85,7 +85,8 @@ _abs_start:
     .option push
     .option norelax
     la gp, __global_pointer$
-    .option pop",
+    .option pop
+    // Allocate stacks",
     #[cfg(all(not(feature = "single-hart"), feature = "s-mode"))]
     "mv t2, a0 // the hartid is passed as parameter by SMODE",
     #[cfg(all(not(feature = "single-hart"), not(feature = "s-mode")))]
@@ -93,9 +94,7 @@ _abs_start:
     #[cfg(not(feature = "single-hart"))]
     "lui t0, %hi(_max_hart_id)
     add t0, t0, %lo(_max_hart_id)
-    bgtu t2, t0, abort",
-    "// Allocate stacks
-    la sp, _stack_start
+    bgtu t2, t0, abort
     lui t0, %hi(_hart_stack_size)
     add t0, t0, %lo(_hart_stack_size)",
     #[cfg(all(not(feature = "single-hart"), riscvm))]
@@ -109,9 +108,10 @@ _abs_start:
     addi t1, t1, -1
     bnez t1, 1b
 2:  ",
-    "sub sp, sp, t0
-
-    // Set frame pointer
+    "la sp, _stack_start",
+    #[cfg(not(feature = "single-hart"))]
+    "sub sp, sp, t0",
+    "// Set frame pointer
     add s0, sp, zero
 
     jal zero, _start_rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,7 @@
 //!
 //! ## `single-hart`
 //!
-//! This feature saves a little code size by removing unnecessary stack space calculation if there is only one hart on the target.
+//! This feature saves a little code size if there is only one hart on the target.
 //!
 //! ## `s-mode`
 //!


### PR DESCRIPTION
The PR https://github.com/rust-embedded/riscv-rt/pull/119 introduced a bug that if feature single-hart is enabled, stack pointer is
not set properly. That is:
```
# near _abs_start
# ...
20000042:	4e81                	li	t4,0
20000044:	4f01                	li	t5,0
20000046:	4f81                	li	t6,0

20000048 <.Lpcrel_hi0>:
20000048:	60000197          	auipc	gp,0x60000
2000004c:	7b818193          	addi	gp,gp,1976 # 80000800 <__global_pointer$>

20000050 <.Lpcrel_hi1>:
20000050:	60008117          	auipc	sp,0x60008
20000054:	fb010113          	addi	sp,sp,-80 # 80008000 <_sstack>
20000058:	000012b7          	lui	t0,0x1
2000005c:	80028293          	addi	t0,t0,-2048 # 800 <_hart_stack_size>
20000060:	40510133          	sub	sp,sp,t0 # BUG here: sp is set to _sstack(equals to _stack_start) - _hart_stack_size
20000064:	840a                	mv	s0,sp
20000066:	0040006f          	j	2000006a <_start_rust>
```
The stack pointer should be set to _stack_start in this case. Also, the operations on _hart_stack_size should be removed.

After the fix:
```
# near _abs_start
# ...
20000042:	4e81                	li	t4,0
20000044:	4f01                	li	t5,0
20000046:	4f81                	li	t6,0

20000048 <.Lpcrel_hi0>:
20000048:	60000197          	auipc	gp,0x60000
2000004c:	7b818193          	addi	gp,gp,1976 # 80000800 <__global_pointer$>

20000050 <.Lpcrel_hi1>:
20000050:	60008117          	auipc	sp,0x60008
20000054:	fb010113          	addi	sp,sp,-80 # 80008000 <_sstack>
20000058:	840a                	mv	s0,sp
2000005a:	0040006f          	j	2000005e <_start_rust>

```

Relevant document is also updated.