### PR TITLE
Ensure sp is 16-byte aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `start_trap_rust` is now marked as `unsafe`
 - Implement `r0` as inline assembly
 - mhartid CSR is no longer read in single-hart mode, assumed zero
+- Ensure stack pointer is 16-byte aligned before jumping to Rust entry point
 
 ## [v0.11.0] - 2023-01-18
 


### PR DESCRIPTION
# The problem
See https://github.com/rust-embedded/riscv-rt/issues/75. and https://github.com/rust-lang/rust/issues/86693.
I did the small experiment to illustrate the problem:
```
#[repr(align(16))]
struct AlignedU8(u8);

pub fn test_align() {
    let _p = AlignedU8(3);
}
```
Generated code(target = riscv32imac-unknown-none-elf):
```
20000228 <_ZN13riscv_rt_test10test_align17hdcaf8a1e3d5da475E>:
20000228:	1141                	addi	sp,sp,-16
2000022a:	450d                	li	a0,3
2000022c:	00a10023          	sb	a0,0(sp)
20000230:	0141                	addi	sp,sp,16
20000232:	8082                	ret
```
We can see that rustc/llvm is supposing that sp is 16-byte aligned to allocate _p(indeed, to do any stack allocations). But if sp is not 16-byte aligned(8 or smaller), _p will be allocated at incorrect location.

# Fix
According to https://github.com/riscv-non-isa/riscv-eabi-spec/blob/master/EABI.adoc#4-eabi-stack-alignment, EABI requires that RV32 stack is 8-byte aligned and 16-byte for RV64. But to achieve max compatibility and to be correct, we could simply force 16-byte. It's small drawback is memory waste of a maximum of 8 bytes.

Fix this by forcing stack pointer to be 16-byte aligned.

Fixes https://github.com/rust-embedded/riscv-rt/issues/75.