### PR TITLE
Deprecate riscv-rt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- moved to `riscv` repository. `riscv-rt` is now deprecated
 - Use inline assembly instead of pre-compiled blobs
 - Removed bors in favor of GitHub Merge Queue
 - `start_trap_rust` is now marked as `unsafe`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 > Minimal runtime / startup for RISC-V CPU's.
 
+**This crate has moved to the [`riscv`] repository, and this repository is
+archived. Please direct issues and pull requests to the new repository.**
+
+[`riscv`]: https://github.com/rust-embedded/riscv
+
 This project is developed and maintained by the [RISC-V team][team].
 
 ## [Documentation](https://docs.rs/crate/riscv-rt)


### PR DESCRIPTION
As now `riscv-rt` is part of [`riscv`](https://github.com/rust-embedded/riscv)'s workspace, it is time to deprecate this repo